### PR TITLE
More infos added in Exception Message for analysis this error:

### DIFF
--- a/src/BCMathService.php
+++ b/src/BCMathService.php
@@ -131,7 +131,7 @@ class BCMathService implements ServiceInterface
         // Check for invalid characters in the supplied base58 string
         foreach ($chars as $char) {
             if (isset($indexes[$char]) === false) {
-                throw new InvalidArgumentException('Argument $base58 contains invalid characters.');
+                throw new InvalidArgumentException('Argument $base58 contains invalid characters. ($char: "'.$char.'" | $base58: "'.$base58.'") ');
             }
         }
 


### PR DESCRIPTION
More infos added in Exception Message for analysis this error:
```
PHP Fatal error:  Uncaught exception 'InvalidArgumentException' with message 'Argument $base58 contains invalid characters.'
```