### PR TITLE
Fix typographical error(s)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ $ bin/phpunit
 ## Benchmarking
 
 You can benchmark this library using [Athletic](https://github.com/polyfractal/athletic).
-The benchmarking suite also benchmarks PHP's built-in Base64 and Base16 encoding for comparision.
+The benchmarking suite also benchmarks PHP's built-in Base64 and Base16 encoding for comparison.
 
 ```bash
 $ bin/athletic -p benchmarks


### PR DESCRIPTION
@stephen-hill, I've corrected a typographical error in the documentation of the [base58php](https://github.com/stephen-hill/base58php) project. Specifically, I've changed comparision to comparison. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.