### PR TITLE
Bcscale

### DIFF
--- a/src/BCMathService.php
+++ b/src/BCMathService.php
@@ -80,7 +80,7 @@ class BCMathService implements ServiceInterface
         // The remainder or modulo on each loop becomes a base 58 character
         $output = '';
         while ($decimal >= $this->base) {
-            $div = bcdiv($decimal, $this->base);
+            $div = bcdiv($decimal, $this->base, 0);
             $mod = bcmod($decimal, $this->base);
             $output .= $this->alphabet[$mod];
             $decimal = $div;
@@ -148,7 +148,7 @@ class BCMathService implements ServiceInterface
         while ($decimal > 0) {
             $byte = bcmod($decimal, 256);
             $output = pack('C', $byte) . $output;
-            $decimal = bcdiv($decimal, 256);
+            $decimal = bcdiv($decimal, 256, 0);
         }
 
         // Now we need to add leading zeros

--- a/tests/Base58Test.php
+++ b/tests/Base58Test.php
@@ -49,7 +49,8 @@ class Base58Tests extends PHPUnit_Framework_TestCase
             array('simply a long string', '2cFupjhnEsSn59qHXstmK2ffpLv2'),
             array("\x00\x61", '12g'),
             array("\x00", '1'),
-            array("\x00\x00", '11')
+            array("\x00\x00", '11'),
+            array('0248ac9d3652ccd8350412b83cb08509e7e4bd41', '3PtvAWwSMPe2DohNuCFYy76JhMV3rhxiSxQMbPBTtiPvYvneWu95XaY')
         );
 
         $return = array();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,3 +2,7 @@
 
 require_once 'vendor/autoload.php';
 date_default_timezone_set("UTC");
+
+// Setting "bcmath.scale" to something other than 0 so that
+// we can be sure bcdiv's $scale parameter is working correctly
+bcscale(16);


### PR DESCRIPTION
It appears that some distributions of PHP override the default value of "bcmath.scale" to something other than zero. This means we must always set bcdiv()'s $scale parameter to zero.