### PR TITLE
Php service, PHP 7.2 support

### DIFF
--- a/benchmarks/Base58PHPEvent.php
+++ b/benchmarks/Base58PHPEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace StephenHill\Benchmarks;
+
+use Athletic\AthleticEvent;
+use StephenHill\Base58;
+use StephenHill\PHPService;
+
+class Base58PHPEvent extends AthleticEvent
+{
+    protected $base58;
+
+    public function setUp()
+    {
+        $this->base58 = new Base58(null, new PHPService());
+    }
+
+    /**
+     * @iterations 10000
+     */
+    public function encodeBase58()
+    {
+        $this->base58->encode('Hello World');
+    }
+
+    /**
+     * @iterations 10000
+     */
+    public function decodeBase58()
+    {
+        $this->base58->decode('JxF12TrwUP45BMd');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
     "name": "stephenhill/base58",
     "description": "Base58 Encoding and Decoding Library for PHP",
     "require-dev": {
-        "phpunit/phpunit": "4.*",
-        "athletic/athletic": "~0.1"
+        "athletic/athletic": "~0.1",
+        "phpunit/phpunit": "^7.4"
     },
     "license": "MIT",
     "authors": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,6 @@
 	convertWarningsToExceptions="true"
 	processIsolation="true"
 	stopOnFailure="false"
-	syntaxCheck="true"
 	beStrictAboutTestsThatDoNotTestAnything="true"
 	beStrictAboutOutputDuringTests="true"
 	verbose="true"

--- a/src/BCMathService.php
+++ b/src/BCMathService.php
@@ -81,7 +81,7 @@ class BCMathService implements ServiceInterface
         $output = '';
         while ($decimal >= $this->base) {
             $div = bcdiv($decimal, $this->base, 0);
-            $mod = bcmod($decimal, $this->base);
+            $mod = (int) bcmod($decimal, $this->base);
             $output .= $this->alphabet[$mod];
             $decimal = $div;
         }

--- a/src/Base58.php
+++ b/src/Base58.php
@@ -57,7 +57,7 @@ class Base58
                 $service = new BCMathService($alphabet);
             }
             else {
-                throw new \Exception('Please install the BC Math or GMP extension.');
+                $service = new PHPService($alphabet);
             }
         }
 

--- a/src/PHPService.php
+++ b/src/PHPService.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace StephenHill;
+
+use InvalidArgumentException;
+
+class PHPService implements ServiceInterface
+{
+    /**
+     * @var string
+     * @since v1.1.0
+     */
+    protected $alphabet;
+
+    /**
+     * @var int
+     * @since v1.1.0
+     */
+    protected $base;
+
+    /**
+     * Constructor
+     *
+     * @param string $alphabet optional
+     * @since v1.1.0
+     */
+    public function __construct($alphabet = null)
+    {
+        // Handle null alphabet
+        if ($alphabet === null) {
+            $alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+        }
+
+        // Type validation
+        if (\is_string($alphabet) === false) {
+            throw new InvalidArgumentException('Argument $alphabet must be a string.');
+        }
+
+        // The alphabet must contain 58 characters
+        if (\strlen($alphabet) !== 58) {
+            throw new InvalidArgumentException('Argument $alphabet must contain 58 characters.');
+        }
+
+        $this->alphabet = $alphabet;
+        $this->base = \strlen($alphabet);
+    }
+    /**
+     * Encode a string into base58.
+     *
+     * @param  string $string The string you wish to encode.
+     * @since Release v1.1.0
+     * @return string The Base58 encoded string.
+     */
+    public function encode($string): string
+    {
+        // Type validation
+        if (\is_string($string) === false) {
+            throw new InvalidArgumentException('Argument $string must be a string.');
+        }
+
+        // If the string is empty, then the encoded string is obviously empty
+        if ($string === '') {
+            return '';
+        }
+
+        // Strings in PHP are essentially 8-bit byte arrays
+        // so lets convert the string into a PHP array
+        $bytes = array_values(unpack('C*', $string));
+
+        $leadingZerosNeeded = 0;
+        foreach ($bytes as $byte) {
+            if ($byte !== 0) {
+                break;
+            }
+
+            $leadingZerosNeeded++;
+        }
+
+        $source = \array_slice($bytes, $leadingZerosNeeded);
+        $result = $this->convertBase($source, 256, 58);
+
+        // Count existing leading zeros
+        $leadingZeroCount = 0;
+        foreach ($result as $digit) {
+            if ($digit !== 0) {
+                break;
+            }
+
+            $leadingZeroCount++;
+        }
+
+        // Now we need to add any missing leading zeros
+        for ($i = $leadingZeroCount; $i < $leadingZerosNeeded; $i++) {
+            array_unshift($result, 0);
+        }
+
+        // Encode to a string
+        return implode('', array_map(function ($ord) { return $this->alphabet[$ord]; }, $result));
+    }
+
+    /**
+     * Decode base58 into a PHP string.
+     *
+     * @param  string $base58 The base58 encoded string.
+     * @since Release v1.1.0
+     * @return string Returns the decoded string.
+     */
+    public function decode($base58): string
+    {
+        // Type Validation
+        if (\is_string($base58) === false) {
+            throw new InvalidArgumentException('Argument $base58 must be a string.');
+        }
+
+        // If the string is empty, then the decoded string is obviously empty
+        if ($base58 === '') {
+            return '';
+        }
+
+        $indexes = array_flip(str_split($this->alphabet));
+        $chars = str_split($base58);
+        $digits = [];
+
+        // Check for invalid characters in the supplied base58 string
+        foreach ($chars as $char) {
+            if (isset($indexes[$char]) === false) {
+                throw new InvalidArgumentException('Argument $base58 contains invalid characters. ($char: "'.$char.'" | $base58: "'.$base58.'") ');
+            }
+
+            $digits[] = $indexes[$char];
+        }
+
+        $leadingZerosNeeded = 0;
+        foreach ($digits as $digit) {
+            if ($digit !== 0) {
+                break;
+            }
+
+            $leadingZerosNeeded++;
+        }
+
+        $source = \array_slice($digits, $leadingZerosNeeded);
+        $result = $this->convertBase($source, 58, 256);
+
+        // Count existing leading zeros
+        $leadingZeroCount = 0;
+        foreach ($result as $digit) {
+            if ($digit !== 0) {
+                break;
+            }
+
+            $leadingZeroCount++;
+        }
+
+        // Now we need to add any missing leading zeros
+        for ($i = $leadingZeroCount; $i < $leadingZerosNeeded; $i++) {
+            array_unshift($result, 0);
+        }
+
+        // Encode to a string
+        return implode('', array_map('\chr', $result));
+    }
+
+    /**
+     * Basic manual base conversion algorithm,
+     * @see https://en.wikipedia.org/wiki/Positional_notation#Base_conversion
+     **/
+    private function convertBase(array $digits, int $base1, int $base2): array
+    {
+        $result = [];
+
+        do {
+            $digitCount = \count($digits);
+            $quotient = [];
+            $remainder = 0;
+
+            for ($i = 0; $i < $digitCount; $i++) {
+                $dividend = $remainder * $base1 + $digits[$i];
+                $quotient[] = intdiv($dividend, $base2);
+                $remainder = $dividend % $base2;
+            }
+
+            $result[] = $remainder;
+            $digits = $quotient;
+        } while (array_sum($quotient) > 0);
+
+        // Now we need to reverse the results
+        return array_reverse($result);
+    }
+}

--- a/tests/Base58Test.php
+++ b/tests/Base58Test.php
@@ -4,6 +4,7 @@ use PHPUnit\Framework\TestCase;
 use StephenHill\Base58;
 use StephenHill\BCMathService;
 use StephenHill\GMPService;
+use StephenHill\PHPService;
 
 class Base58Tests extends TestCase
 {
@@ -33,7 +34,8 @@ class Base58Tests extends TestCase
     {
         $instances = array(
             new Base58(null, new BCMathService()),
-            new Base58(null, new GMPService())
+            new Base58(null, new GMPService()),
+            new Base58(null, new PHPService()),
         );
 
         $tests = array(

--- a/tests/Base58Test.php
+++ b/tests/Base58Test.php
@@ -1,10 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use StephenHill\Base58;
 use StephenHill\BCMathService;
 use StephenHill\GMPService;
 
-class Base58Tests extends PHPUnit_Framework_TestCase
+class Base58Tests extends TestCase
 {
     /**
      * @dataProvider encodingsProvider


### PR DESCRIPTION
## Background
In the course of my day job, I needed to add base58 support but could not use the `bcmath` or `gmp` modules.  To support that I wrote a pure PHP service.

To work with our environment I had to make a couple of changes to support PHP 7.2

## Deficiencies
I'm aware it has (at least) the following issues:
- [ ] Need to separate `PHPService` updates from PHP 7.2 compatibility updates
- [ ] Need to make it PHP 5.3 compatible
but I wanted to get discussion started so I can avoid repeating any other mistakes I have made

## Performance
According to the included benchmarks, on my machine the pure PHP implementation is actually faster than the `bcmath` implementation:

```
StephenHill\Benchmarks\Base16Event
    Method Name    Iterations    Average Time      Ops/second
    ------------  ------------  --------------    -------------
    encodeBase16: [10,000    ] [0.0000000098705] [101,311,690.82126]
    decodeBase16: [10,000    ] [0.0000001375437] [7,270,417.75004]


StephenHill\Benchmarks\Base58BCMathEvent
    Method Name    Iterations    Average Time      Ops/second
    ------------  ------------  --------------    -------------
    encodeBase58: [10,000    ] [0.0000283010483] [35,334.38020]
    decodeBase58: [10,000    ] [0.0000288946390] [34,608.49604]


StephenHill\Benchmarks\Base58GMPEvent
    Method Name    Iterations    Average Time      Ops/second
    ------------  ------------  --------------    -------------
    encodeBase58: [10,000    ] [0.0000095309734] [104,921.07725]
    decodeBase58: [10,000    ] [0.0000168622017] [59,304.23668]


StephenHill\Benchmarks\Base58PHPEvent
    Method Name    Iterations    Average Time      Ops/second
    ------------  ------------  --------------    -------------
    encodeBase58: [10,000    ] [0.0000179829836] [55,608.12504]
    decodeBase58: [10,000    ] [0.0000192520618] [51,942.48845]


StephenHill\Benchmarks\Base64Event
    Method Name    Iterations    Average Time      Ops/second
    ------------  ------------  --------------    -------------
    encodeBase64: [10,000    ] [0.0000000110626] [90,394,482.75863]
    decodeBase64: [10,000    ] [0.0000000604630] [16,539,053.62776]
```

I have an idea that this is at least partially because I do a direct base change from 256 to 58, while the included services do 256->10->58 instead.  I envision experimenting with altering the `bcmath` and `gmp` algorithms similarly to see if they also speed up.